### PR TITLE
Fix ForCondition time duration check

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -73,7 +73,7 @@ template<typename... Ts> class ForCondition : public Condition<Ts...>, public Co
   bool check(Ts... x) override {
     if (!this->check_internal())
       return false;
-    return millis() - this->last_inactive_ < this->time_.value(x...);
+    return millis() - this->last_inactive_ >= this->time_.value(x...);
   }
 
  protected:


### PR DESCRIPTION
## Description:

According documentation ForCondition should evaluate to true if a nested condition is true for at least the specified time duration and not the less.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
